### PR TITLE
support additional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,32 @@ remote machine.
 
 ##### positional arguments:
       -p PROJECT, --project PROJECT
-                            The name of your local git project, stored under your
-                            default path. Default: /Users/nmagnezi/git/<project>
+                            The name of your git project, stored under your
+                            local/remote path.
 
       -d {to,from}, --direction {to,from}
                             Sync Direction
     
-      -i IP, --ip IP        IP Address for SSH connection
+      -i IP, --ip IP        IP Address or FQDN for SSH connection
 
 
 ##### optional arguments:
-      -f FOLDER, --folder FOLDER
-                            Remote git folder. Default: /opt/stack/
+      -r REMOTE, --remote REMOTE
+                            Remote git folder. Default: ~/git
+
+      -l LOCAL, --local LOCAL
+                            Local git folder. Default: ~/git
     
       -u USER, --user USER  Username for ssh connection. Default: stack
 
+      -e [EXCLUDE [EXCLUDE ...]], --exclude [EXCLUDE [EXCLUDE ...]]
+                            Exclude list for rsync. Default: ['.tox', '.idea',
+                            '.pyc', '.pyo', '.swp', '.swo', '.git', '.iml',
+                            'target', 'build', '__pycache__']
+
 ## Usage Example
 
-    codesync -p octavia -d to -i 10.35.6.107 -f /my/path -u blah
+    codesync -p myproject -d from -i 10.35.6.107 -u nmagnezi -r /Users/nmagnezi/git -l ~/git -e .git .tox
 
 ## How does it work?
 

--- a/codesync/codesync.py
+++ b/codesync/codesync.py
@@ -31,15 +31,20 @@ def process_args():
     parser.add_argument(
         '-p', '--project',
         required=True,
-        help='The name of your local git project, stored under your default '
-             'path. Default: {}{}'
-             .format(helpers.get_git_directory_path(), '<project>')
+        help='The name of your git project, stored under your'
+             'local/remote path.'
     )
     parser.add_argument(
-        '-f', '--folder',
+        '-r', '--remote',
         required=False,
         default=constants.REMOTE_PATH,
         help='Remote git folder. Default: {} '.format(constants.REMOTE_PATH)
+    )
+    parser.add_argument(
+        '-l', '--local',
+        required=False,
+        default=helpers.get_git_directory_path(),
+        help='Local git folder. Default: {} '.format(helpers.get_git_directory_path())
     )
     parser.add_argument(
         '-d', '--direction',
@@ -57,7 +62,15 @@ def process_args():
     parser.add_argument(
         '-i', '--ip',
         required=True,
-        help='IP Address for ssh connection'
+        help='IP Address of FQDN for ssh connection'
+    )
+    parser.add_argument(
+        '-e', '--exclude',
+        required=False,
+        nargs='*',
+        type=str,
+        default=constants.RSYNC_EXCLUDE,
+        help='Exclude list for rsync. Default: {} '.format(constants.RSYNC_EXCLUDE)
     )
     return parser.parse_args()
 
@@ -66,19 +79,20 @@ def main():
     rsync = helpers.get_rsync_path()
     args = process_args()
     local = helpers.get_git_directory_path()
-    remote = "".join([args.user, '@', args.ip, ':', args.folder])
+    remote = "".join([args.user, '@', args.ip, ':', args.remote])
+    rsync_args = constants.RSYNC_ARGS + helpers.get_rsync_exclude(args.exclude)
     if args.direction == 'to':
         cmd = " ".join([rsync,
-                        constants.RSYNC_ARGS,
+                        rsync_args,
                         path.join(local, args.project),
                         remote])
     else:
         cmd = " ".join([rsync,
-                        constants.RSYNC_ARGS,
-                        "".join([remote, args.project]),
+                        rsync_args,
+                        path.join(remote, args.project),
                         local])
 
-    print "Executing: " + "".join(cmd)
+    print("Executing: " + "".join(cmd))
     call(cmd.split())
 
 

--- a/codesync/constants.py
+++ b/codesync/constants.py
@@ -14,12 +14,12 @@
 #    under the License.
 
 GIT_DIR = "git/"
-REMOTE_PATH = "/opt/stack/"
+REMOTE_PATH = "~/git"
 
 SSH_USER = "stack"
 RSYNC_BINARY = "rsync"
 
 # Excludes list composed with the kind help of John Schwarz: https://github.com/jschwarz89
-RSYNC_ARGS = ("-v -r --exclude=.tox --exclude=.idea --exclude=*.pyc "
-              "--exclude=*.pyo --exclude=*~ --exclude=.*.swp --exclude=.*.swo "
-              "-azh --progress --delete")
+RSYNC_ARGS = ("-v -r -azh --progress --delete")
+
+RSYNC_EXCLUDE = ['.tox', '.idea', '.pyc', '.pyo', '.swp', '.swo', '.git', '.iml', 'target', 'build', '__pycache__']

--- a/codesync/helpers.py
+++ b/codesync/helpers.py
@@ -31,3 +31,6 @@ def get_rsync_path():
         raise RuntimeError('rsync is not installed, cannot continue. '
                            'Please install rsync and try again.')
     return rsync
+
+def get_rsync_exclude(exclude):
+    return "".join([" --exclude " + e for e in exclude])


### PR DESCRIPTION
Added the following args:
- exclude: list for rsync --exclude (e.g. '-e .git .tox')
- local: for specifying local git folder
- remote: for specifying remote git folder

Note:  Fixed syntax to support python3